### PR TITLE
- The top-level root class must use the @MetaData annotation in order…

### DIFF
--- a/app/src/main/java/io/github/mainmethod0126/search/condition/metadata/annotation/MetaData.java
+++ b/app/src/main/java/io/github/mainmethod0126/search/condition/metadata/annotation/MetaData.java
@@ -10,4 +10,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MetaData {
     String key() default "";
+
+    int maxDepth() default 3;
 }

--- a/app/src/main/java/io/github/mainmethod0126/search/condition/metadata/annotation/MetaDataField.java
+++ b/app/src/main/java/io/github/mainmethod0126/search/condition/metadata/annotation/MetaDataField.java
@@ -42,4 +42,7 @@ public @interface MetaDataField {
 
     String[] operators() default {};
 
+    int maxDepth() default 5;
+
+
 }

--- a/app/src/test/java/io/github/mainmethod0126/search/condition/metadata/MetaDataGeneratorTest.java
+++ b/app/src/test/java/io/github/mainmethod0126/search/condition/metadata/MetaDataGeneratorTest.java
@@ -1,9 +1,12 @@
 package io.github.mainmethod0126.search.condition.metadata;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import io.github.mainmethod0126.search.condition.metadata.domain.TestHuman;
+import io.github.mainmethod0126.search.condition.metadata.domain.TestLocalDateTime;
 import io.github.mainmethod0126.search.condition.metadata.domain.TestOrder;
 import io.github.mainmethod0126.search.condition.metadata.util.MetaDataGenerator;
 
@@ -14,6 +17,29 @@ public class MetaDataGeneratorTest {
     public void testGenerator_whenNormalParam_thenSuccess() {
 
         String result = MetaDataGenerator.generate(TestOrder.class);
+
+        System.out.println("metadata : " + result);
+
+        assertThat(result).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("Generates metadata from a domain class with a recursive structure")
+    public void testGenerator_whenRecursiveParam_thenSuccess() {
+
+        String result = MetaDataGenerator.generate(TestHuman.class);
+
+        System.out.println("metadata : " + result);
+
+        assertThat(result).isNotNull().isNotEmpty();
+
+    }
+
+    @Test
+    @DisplayName("Generates metadata from a domain class that has a member of LocalDateTime type")
+    public void testGenerator_whenLocalDateTimeParam_thenSuccess() {
+
+        String result = MetaDataGenerator.generate(TestLocalDateTime.class);
 
         System.out.println("metadata : " + result);
 

--- a/app/src/test/java/io/github/mainmethod0126/search/condition/metadata/domain/TestHuman.java
+++ b/app/src/test/java/io/github/mainmethod0126/search/condition/metadata/domain/TestHuman.java
@@ -1,0 +1,20 @@
+package io.github.mainmethod0126.search.condition.metadata.domain;
+
+import io.github.mainmethod0126.search.condition.metadata.annotation.MetaData;
+import io.github.mainmethod0126.search.condition.metadata.annotation.MetaDataField;
+
+@MetaData(maxDepth = 3)
+public class TestHuman {
+
+    private String name;
+
+    private int age;
+
+    private String gender;
+
+    @MetaDataField(maxDepth = 5)
+    private TestHuman child;
+
+    @MetaDataField(maxDepth = 2)
+    private TestParent parent;
+}

--- a/app/src/test/java/io/github/mainmethod0126/search/condition/metadata/domain/TestLocalDateTime.java
+++ b/app/src/test/java/io/github/mainmethod0126/search/condition/metadata/domain/TestLocalDateTime.java
@@ -1,0 +1,12 @@
+package io.github.mainmethod0126.search.condition.metadata.domain;
+
+import java.time.LocalDateTime;
+
+import io.github.mainmethod0126.search.condition.metadata.annotation.MetaData;
+
+@MetaData
+public class TestLocalDateTime {
+
+    private LocalDateTime now;
+
+}

--- a/app/src/test/java/io/github/mainmethod0126/search/condition/metadata/domain/TestParent.java
+++ b/app/src/test/java/io/github/mainmethod0126/search/condition/metadata/domain/TestParent.java
@@ -1,0 +1,11 @@
+package io.github.mainmethod0126.search.condition.metadata.domain;
+
+
+public class TestParent {
+
+    private TestHuman mother;
+
+    private TestHuman father;
+
+
+}


### PR DESCRIPTION
… to be eligible for generation.

- I have added the functionality of @MetaData(maxDepth = int) for recursive structures that have members of the same type as themselves, along with the option to specify @MetaDataField(maxDepth = int) for each field. This prevents infinite recursion.